### PR TITLE
e2e_test: sort resources by kind+name before diff

### DIFF
--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -5,14 +5,14 @@ failures=0
 for test in $(find ./examples/ -maxdepth 1 -mindepth 1 -type f); do
   echo "Testing $test"
   # get output of the template
-  templateOut=$(oc process --local -f $test -o yaml | yq -S .items[])
+  templateOut=$(oc process --local -f $test -o yaml | yq '.items | sort_by(.kind, .metadata.name)')
   # convert template to chart
   template2helm convert --template $test --chart /tmp/charts > /dev/null
   # find newly created chart
   chart=$(ls -td /tmp/charts/*/ | head -1)
   echo "Resulting chart: $chart"
   # get output of chart
-  chartOut=$(helm template $chart | yq -S .)
+  chartOut=$(helm template $chart | yq -s 'sort_by(.kind, .metadata.name)')
   # compare resources produced
   gap=$(diff <(echo "$templateOut") <(echo "$chartOut"))
   if [[ "${gap}x" != "x" ]]; then


### PR DESCRIPTION
This PR uses the yq/jq `sort_by` function to sort output during test runs by the `kind` and `metadata.name` of the resources. This fixes the ordering before the diff, and provides more targeted errors from the diff output.

A side effect, yq can only sort arrays. Minor changes were made to each command in order to ensure the value piped into the sort was an array.

PS This pull request must come after #3 .

Following is example updated output for a failing test:

```
2020-02-02T16:43:34.6817304Z Testing ./examples/js-app-deploy.yml
2020-02-02T16:43:35.2757166Z 2020/02/02 16:43:35 Creating a template for object templates/imagestream.yaml
2020-02-02T16:43:35.2758492Z 2020/02/02 16:43:35 Creating a template for object templates/deploymentconfig.yaml
2020-02-02T16:43:35.2762980Z 2020/02/02 16:43:35 Creating a template for object templates/service.yaml
2020-02-02T16:43:35.2764977Z 2020/02/02 16:43:35 Creating a template for object templates/route.yaml
2020-02-02T16:43:35.2766973Z 2020/02/02 16:43:35 Creating a template for object templates/rolebinding.yaml
2020-02-02T16:43:35.2768583Z 2020/02/02 16:43:35 Convert parameter NAME to value .name
2020-02-02T16:43:35.2769188Z 2020/02/02 16:43:35 Convert parameter APP_TAG to value .app_tag
2020-02-02T16:43:35.2770436Z 2020/02/02 16:43:35 Convert parameter NAMESPACE to value .namespace
2020-02-02T16:43:35.2770761Z 2020/02/02 16:43:35 Convert parameter DEPLOYER_USER to value .deployer_user
2020-02-02T16:43:35.2771287Z 2020/02/02 16:43:35 Convert parameter PIPELINES_NAMESPACE to value .pipelines_namespace
2020-02-02T16:43:35.2811825Z Resulting chart: /tmp/charts/js-app-deploy/
2020-02-02T16:43:35.4528440Z Test Failed!
2020-02-02T16:43:35.4533315Z 2,3c2,23
2020-02-02T16:43:35.4533690Z <   "apiVersion": "image.openshift.io/v1",
2020-02-02T16:43:35.4533982Z <   "kind": "ImageStream",
2020-02-02T16:43:35.4534887Z ---
2020-02-02T16:43:35.4535206Z >   "apiVersion": "v1",
2020-02-02T16:43:35.4535513Z >   "kind": "RoleBinding",
2020-02-02T16:43:35.4535641Z 
2020-02-02T16:43:35.4535727Z 
2020-02-02T16:43:35.4536114Z >   "metadata": {
2020-02-02T16:43:35.4536455Z >     "name": "edit"
2020-02-02T16:43:35.4536945Z Testing ./examples/slack-notify-job-template.yml
2020-02-02T16:43:35.4537299Z >   },
2020-02-02T16:43:35.4537571Z >   "roleRef": {
2020-02-02T16:43:35.4537850Z >     "name": "edit"
2020-02-02T16:43:35.4538398Z >   },
2020-02-02T16:43:35.4538703Z >   "subjects": [
2020-02-02T16:43:35.4538976Z >     {
2020-02-02T16:43:35.4539303Z >       "kind": "ServiceAccount",
2020-02-02T16:43:35.4540282Z >       "name": "jenkins",
2020-02-02T16:43:35.4541373Z >       "namespace": "abc-build"
2020-02-02T16:43:35.4541689Z >     }
2020-02-02T16:43:35.4541950Z >   ],
2020-02-02T16:43:35.4542234Z >   "userNames": [
2020-02-02T16:43:35.4542750Z >     "system:serviceaccount:abc-build:bob"
2020-02-02T16:43:35.4543067Z >   ]
2020-02-02T16:43:35.4543298Z > }
2020-02-02T16:43:35.4543543Z > {
2020-02-02T16:43:35.4543809Z >   "apiVersion": "v1",
2020-02-02T16:43:35.4544113Z >   "kind": "Service",
2020-02-02T16:43:35.4544356Z 6,7c26
2020-02-02T16:43:35.4544638Z <       "build": "abc",
2020-02-02T16:43:35.4545195Z <       "template": "js-app-deploy-template"
2020-02-02T16:43:35.4545649Z ---
2020-02-02T16:43:35.4545965Z >       "name": "abc"
2020-02-02T16:43:35.4546217Z 11c30,44
2020-02-02T16:43:35.4546487Z <   "spec": {}
2020-02-02T16:43:35.4546921Z ---
2020-02-02T16:43:35.4547185Z >   "spec": {
2020-02-02T16:43:35.4547461Z >     "ports": [
2020-02-02T16:43:35.4547736Z >       {
2020-02-02T16:43:35.4548250Z >         "name": "8080-tcp",
2020-02-02T16:43:35.4548565Z >         "port": 8080,
2020-02-02T16:43:35.4548847Z >         "protocol": "TCP",
2020-02-02T16:43:35.4549148Z >         "targetPort": 8080
2020-02-02T16:43:35.4549421Z >       }
2020-02-02T16:43:35.4549685Z >     ],
2020-02-02T16:43:35.4549944Z >     "selector": {
2020-02-02T16:43:35.4550224Z >       "name": "abc"
2020-02-02T16:43:35.4550483Z >     },
2020-02-02T16:43:35.4550780Z >     "sessionAffinity": "None",
2020-02-02T16:43:35.4551070Z >     "type": "ClusterIP"
2020-02-02T16:43:35.4551314Z >   }
2020-02-02T16:43:35.4551560Z 14c47
2020-02-02T16:43:35.4551859Z <   "apiVersion": "apps.openshift.io/v1",
2020-02-02T16:43:35.4552305Z ---
2020-02-02T16:43:35.4552587Z >   "apiVersion": "v1",
2020-02-02T16:43:35.4552848Z 18,19c51
2020-02-02T16:43:35.4553130Z <       "app": "abc",
2020-02-02T16:43:35.4553668Z <       "template": "js-app-deploy-template"
2020-02-02T16:43:35.4554125Z ---
2020-02-02T16:43:35.4554408Z >       "app": "abc"
2020-02-02T16:43:35.4554673Z 83c115
2020-02-02T16:43:35.4554956Z <   "kind": "Service",
2020-02-02T16:43:35.4555388Z ---
2020-02-02T16:43:35.4555688Z >   "kind": "ImageStream",
2020-02-02T16:43:35.4555948Z 86,87c118
2020-02-02T16:43:35.4556212Z <       "name": "abc",
2020-02-02T16:43:35.4556725Z <       "template": "js-app-deploy-template"
2020-02-02T16:43:35.4557198Z ---
2020-02-02T16:43:35.4557499Z >       "build": "abc"
2020-02-02T16:43:35.4557751Z 91,105c122
2020-02-02T16:43:35.4558021Z <   "spec": {
2020-02-02T16:43:35.4558297Z <     "ports": [
2020-02-02T16:43:35.4558552Z <       {
2020-02-02T16:43:35.4559032Z <         "name": "8080-tcp",
2020-02-02T16:43:35.4559333Z <         "port": 8080,
2020-02-02T16:43:35.4559607Z <         "protocol": "TCP",
2020-02-02T16:43:35.4559923Z <         "targetPort": 8080
2020-02-02T16:43:35.4560171Z <       }
2020-02-02T16:43:35.4560444Z <     ],
2020-02-02T16:43:35.4560708Z <     "selector": {
2020-02-02T16:43:35.4560971Z <       "name": "abc"
2020-02-02T16:43:35.4561434Z <     },
2020-02-02T16:43:35.4561710Z <     "sessionAffinity": "None",
2020-02-02T16:43:35.4561994Z <     "type": "ClusterIP"
2020-02-02T16:43:35.4562256Z <   }
2020-02-02T16:43:35.4562704Z ---
2020-02-02T16:43:35.4562978Z >   "spec": {}
2020-02-02T16:43:35.4563230Z 108c125
2020-02-02T16:43:35.4563533Z <   "apiVersion": "route.openshift.io/v1",
2020-02-02T16:43:35.4563977Z ---
2020-02-02T16:43:35.4564276Z >   "apiVersion": "v1",
2020-02-02T16:43:35.4564531Z 112,113c129
2020-02-02T16:43:35.4564830Z <       "name": "abc",
2020-02-02T16:43:35.4565366Z <       "template": "js-app-deploy-template"
2020-02-02T16:43:35.4565821Z ---
2020-02-02T16:43:35.4566108Z >       "name": "abc"
2020-02-02T16:43:35.4566356Z 128,150d143
2020-02-02T16:43:35.4566607Z < }
2020-02-02T16:43:35.4566855Z < {
2020-02-02T16:43:35.4567154Z <   "apiVersion": "authorization.openshift.io/v1",
2020-02-02T16:43:35.4567449Z <   "kind": "RoleBinding",
2020-02-02T16:43:35.4567729Z <   "metadata": {
2020-02-02T16:43:35.4568013Z <     "labels": {
2020-02-02T16:43:35.4568633Z <       "template": "js-app-deploy-template"
2020-02-02T16:43:35.4568907Z <     },
2020-02-02T16:43:35.4569190Z <     "name": "edit"
2020-02-02T16:43:35.4569459Z <   },
2020-02-02T16:43:35.4569729Z <   "roleRef": {
2020-02-02T16:43:35.4569993Z <     "name": "edit"
2020-02-02T16:43:35.4570272Z <   },
2020-02-02T16:43:35.4570529Z <   "subjects": [
2020-02-02T16:43:35.4570769Z <     {
2020-02-02T16:43:35.4571080Z <       "kind": "ServiceAccount",
2020-02-02T16:43:35.4571357Z <       "name": "jenkins",
2020-02-02T16:43:35.4571905Z <       "namespace": "abc-build"
2020-02-02T16:43:35.4572170Z <     }
2020-02-02T16:43:35.4572415Z <   ],
2020-02-02T16:43:35.4572666Z <   "userNames": [
2020-02-02T16:43:35.4573164Z <     "system:serviceaccount:abc-build:bob"
2020-02-02T16:43:35.4573445Z <   ]
```