### PR TITLE
Update legacy versions

### DIFF
--- a/examples/jenkins-s2i-build-template-with-secret.yml
+++ b/examples/jenkins-s2i-build-template-with-secret.yml
@@ -11,13 +11,13 @@ metadata:
     tags: instant-app,jenkins
 objects:
 - kind: ImageStream
-  apiVersion: v1
+  apiVersion: image.openshift.io/v1
   metadata:
     name: "${NAME}"
     annotations:
       description: Keeps track of changes in the application image
 - kind: ImageStream
-  apiVersion: v1
+  apiVersion: image.openshift.io/v1
   metadata:
     name: ${BUILDER_IMAGE_STREAM_NAME}
     annotations:
@@ -33,7 +33,7 @@ objects:
       referencePolicy:
         type: Source
 - kind: BuildConfig
-  apiVersion: v1
+  apiVersion: build.openshift.io/v1
   metadata:
     name: "${NAME}"
     labels:

--- a/examples/js-app-deploy.yml
+++ b/examples/js-app-deploy.yml
@@ -9,14 +9,14 @@ metadata:
     iconClass: icon-cube
     tags: http
 objects:
-- apiVersion: v1
+- apiVersion: image.openshift.io/v1
   kind: ImageStream
   metadata:
     labels:
       build: "${NAME}"
     name: "${NAME}"
   spec: {}
-- apiVersion: v1
+- apiVersion: apps.openshift.io/v1
   kind: DeploymentConfig
   metadata:
     name: "${NAME}"
@@ -79,7 +79,7 @@ objects:
       name: "${NAME}"
     sessionAffinity: None
     type: ClusterIP
-- apiVersion: v1
+- apiVersion: route.openshift.io/v1
   kind: Route
   metadata:
     labels:
@@ -93,7 +93,7 @@ objects:
       name: "${NAME}"
       weight: 100
     wildcardPolicy: None
-- apiVersion: v1
+- apiVersion: authorization.openshift.io/v1
   kind: RoleBinding
   metadata:
     name: edit


### PR DESCRIPTION
This is a small update to change the apiVersions in a few of the example templates to not use `v1`.